### PR TITLE
Add `PrevPosOverrideIndex`

### DIFF
--- a/Patches/Patch_CP_Bioscan_Core_Setup.cs
+++ b/Patches/Patch_CP_Bioscan_Core_Setup.cs
@@ -36,7 +36,10 @@ namespace ScanPosOverride.Patches
                 }
                 else if (def != null && def.PrevPosOverrideIndex > 0)
                 {
-                    prevPuzzlePos = PuzzleOverrideManager.Current.GetBioscanCore(def.PrevPosOverrideIndex).m_position;
+                    var overridePosition = PuzzleOverrideManager.Current.GetBioscanCore(def.PrevPosOverrideIndex)?.m_position
+                    ?? PuzzleOverrideManager.Current.GetClusterCore(def.PrevPosOverrideIndex)?.transform.position
+                    ?? prevPuzzlePos; // default to what it already was if getting either of the previous fails
+                    prevPuzzlePos = overridePosition;
                 }
                 else
                 {
@@ -80,7 +83,10 @@ namespace ScanPosOverride.Patches
                 }
                 else if (def != null && def.PrevPosOverrideIndex > 0)
                 {
-                    prevPuzzlePos = PuzzleOverrideManager.Current.GetBioscanCore(def.PrevPosOverrideIndex).m_position;
+                    var overridePosition = PuzzleOverrideManager.Current.GetBioscanCore(def.PrevPosOverrideIndex)?.m_position
+                    ?? PuzzleOverrideManager.Current.GetClusterCore(def.PrevPosOverrideIndex)?.transform.position
+                    ?? prevPuzzlePos; // default to what it already was if getting either of the previous fails
+                    prevPuzzlePos = overridePosition;
                 }
                 else
                 {

--- a/Patches/Patch_CP_Bioscan_Core_Setup.cs
+++ b/Patches/Patch_CP_Bioscan_Core_Setup.cs
@@ -34,6 +34,10 @@ namespace ScanPosOverride.Patches
                 {
                     prevPuzzlePos = def.PrevPosOverride.ToVector3();
                 }
+                else if (def != null && def.PrevPosOverrideIndex > 0)
+                {
+                    prevPuzzlePos = PuzzleOverrideManager.Current.GetBioscanCore(def.PrevPosOverrideIndex).m_position;
+                }
                 else
                 {
                     if (puzzleIndex == 0)
@@ -73,6 +77,10 @@ namespace ScanPosOverride.Patches
                 if (def != null && def.PrevPosOverride.ToVector3() != Vector3.zero)
                 {
                     prevPuzzlePos = def.PrevPosOverride.ToVector3();
+                }
+                else if (def != null && def.PrevPosOverrideIndex > 0)
+                {
+                    prevPuzzlePos = PuzzleOverrideManager.Current.GetBioscanCore(def.PrevPosOverrideIndex).m_position;
                 }
                 else
                 {

--- a/Patches/Patch_CP_Cluster_Core_Setup.cs
+++ b/Patches/Patch_CP_Cluster_Core_Setup.cs
@@ -35,6 +35,10 @@ namespace ScanPosOverride.Patches
             {
                 prevPuzzlePos = def.PrevPosOverride.ToVector3();
             }
+            else if (def != null && def.PrevPosOverrideIndex > 0)
+            {
+                prevPuzzlePos = PuzzleOverrideManager.Current.GetBioscanCore(def.PrevPosOverrideIndex).m_position;
+            }
             else
             {
                 if (puzzleIndex == 0)

--- a/Patches/Patch_CP_Cluster_Core_Setup.cs
+++ b/Patches/Patch_CP_Cluster_Core_Setup.cs
@@ -37,7 +37,11 @@ namespace ScanPosOverride.Patches
             }
             else if (def != null && def.PrevPosOverrideIndex > 0)
             {
-                prevPuzzlePos = PuzzleOverrideManager.Current.GetBioscanCore(def.PrevPosOverrideIndex).m_position;
+                var overridePosition = PuzzleOverrideManager.Current.GetBioscanCore(def.PrevPosOverrideIndex)?.m_position
+                    ?? PuzzleOverrideManager.Current.GetClusterCore(def.PrevPosOverrideIndex)?.transform.position
+                    ?? prevPuzzlePos; // default to what it already was if getting either of the previous fails
+                prevPuzzlePos = overridePosition;
+
             }
             else
             {

--- a/PuzzleOverrideData/PuzzleOverride.cs
+++ b/PuzzleOverrideData/PuzzleOverride.cs
@@ -28,6 +28,7 @@ namespace ScanPosOverride.PuzzleOverrideData
         public bool HideSpline { get; set; } = false;
 
         public Vec3 PrevPosOverride { get; set; } = new Vec3();
+        public uint PrevPosOverrideIndex { get; set; } = 0;
 
         public bool ConcurrentCluster { get; set; } = false;
 


### PR DESCRIPTION
Specify OverrideIndex for scan position to spline from if `PrevPosOverride` is omitted.


https://github.com/Inas-07/ExtraChainedPuzzleCustomization/assets/15879336/ecff19a1-0422-4f97-a784-4fca5e4c01bf

