### PR TITLE
Fix EventsOnProgress not getting reset after checkpoint

### DIFF
--- a/Patches/Patch_CP_Bioscan_Core_OnSyncStateChanged.cs
+++ b/Patches/Patch_CP_Bioscan_Core_OnSyncStateChanged.cs
@@ -52,6 +52,7 @@ namespace ScanPosOverride.Patches
                     int i = EOPIndex[__instance.Pointer];
                     if (isDropinState)
                     {
+                        i = 0; // full reset to rerun events
                         while (i < def.EventsOnBioscanProgress.Count)
                         {
                             var curEOP = def.EventsOnBioscanProgress[i];
@@ -64,6 +65,7 @@ namespace ScanPosOverride.Patches
                                 i++;
                             }
                         }
+                        EOPIndex[__instance.Pointer] = i; // actually set the index to where it's supposed to be
                         return;
                     }
 


### PR DESCRIPTION
If an EventOnProgress event was triggered during a scan, then a checkpoint was loaded to before the scan, then then the EOP index would remain where it was prior and continue once the scan reached that percentage.

For example:
```json
{
  "EventsOnBioscanProgress": [
    {
      "Progress": 0.25,
      "Events": [
        {
          "WardenIntel": "1"
        }
      ]
    },
    {
      "Progress": 0.5,
      "Events": [
        {
          "WardenIntel": "2"
        }
      ]
    },
    {
      "Progress": 0.75,
      "Events": [
        {
          "WardenIntel": "3"
        }
      ]
    }
  ]
}
```

If a checkpoint was saved before starting this scan, progress was made up to 60% on the scan and then players died, then before dying they would have seen intel popups saying "1" and "2". However, upon reloading the checkpoint, they would see no intel popups until 75%, upon which they would finally see "3".